### PR TITLE
PEP 693: Update 3.12.5 release date

### DIFF
--- a/peps/pep-0693.rst
+++ b/peps/pep-0693.rst
@@ -61,10 +61,10 @@ Actual:
 - 3.12.2: Tuesday, 2024-02-06
 - 3.12.3: Tuesday, 2024-04-09
 - 3.12.4: Thursday, 2024-06-06
+- 3.12.5: Wednesday, 2024-08-07
 
 Expected:
 
-- 3.12.5: Tuesday, 2024-08-06
 - 3.12.6: Tuesday, 2024-10-01
 - 3.12.7: Tuesday, 2024-12-03
 - 3.12.8: Tuesday, 2025-02-04
@@ -98,5 +98,3 @@ Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal
 license, whichever is more permissive.
-
-


### PR DESCRIPTION
source: https://discuss.python.org/t/python-3-12-5-now-available/60219

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--1.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->